### PR TITLE
Create template for QAP ternary diagram

### DIFF
--- a/pyrolite/data/models/QAP/config.json
+++ b/pyrolite/data/models/QAP/config.json
@@ -1,0 +1,59 @@
+
+{"name": "QAP-classification", "axes": {"t": "Quartz", "l": "Alkali Feldspar", "r": "Plagioclase"}, "transform": "ternary",
+    "fields": {
+        "quartzolite": {
+            "name": "Quartzolite",
+            "poly": [[100, 0, 0], [90, 10, 0], [90, 0, 10]]},
+        "quart-granitoid": {
+            "name": "Quartz-rich Granitoid",
+            "poly": [[90, 10, 0], [90, 0, 10], [60, 0, 40], [60, 40, 0]]},
+        "alkali-fspar-granite": {
+            "name": "Alkali Feldspar Granite",
+            "poly": [[60, 40, 0], [60, 36, 4], [20, 72, 8], [20, 80, 0]]},
+        "quartz-alkali-fspar-syenite": {
+            "name": "Quartz Alkali Feldspar Granite",
+            "poly": [[20, 80, 0], [20, 72, 8], [5, 85.5, 9.5], [5, 95, 0]]},
+        "alkali-feldspar-syenite": {
+            "name": "Alkali Feldspar Syenite",
+            "poly": [[5, 95, 0], [5, 85.5, 9.5], [0, 90, 10], [0, 100, 0]]},
+        "syenogranite": {
+            "name": "Syenogranite",
+            "poly": [[60, 36, 4], [60, 26, 14], [20, 52, 28], [20, 72, 8]]},
+        "quartz-syenite": {
+            "name": "Quartz Syenite",
+            "poly": [[20, 72, 8], [20, 52, 28], [5, 61.75, 33.25], [5, 85.5, 9.5]]},
+        "syenite": {
+            "name": "Syenite",
+            "poly": [[5, 85.5, 9.5], [5, 61.75, 33.25], [0, 65, 35], [0, 90, 10]]},
+        "monzogranite": {
+            "name": "Monzogranite",
+            "poly": [[60, 26, 14], [60, 14, 26], [20, 28, 52], [20, 52, 28]]},
+        "quartz-monzonite": {
+            "name": "Quartz Monzonite",
+            "poly": [[20, 52, 28], [20, 28, 52], [5, 33.25, 61.75], [5, 61.75, 33.25]]},
+        "monzonite": {
+            "name": "Monzonite",
+            "poly": [[5, 61.75, 33.25], [5, 33.25, 61.75], [0, 35, 65], [0, 65, 35]]},
+        "granodiorite": {
+            "name": "Granodiorite",
+            "poly": [[60, 14, 26], [60, 4, 36], [20, 8, 72], [20, 28, 52]]},
+        "quartz-monzodiorite-monzogabbro": {
+            "name": "Quartz Monzodiorite/Monzogabbro",
+            "poly": [[20, 28, 52], [20, 8, 72], [5, 9.5, 85.5], [5, 33.25, 61.75]]},
+        "monzodiorite-monzogabbro": {
+            "name": "Monzodiorite/Monzogabbro",
+            "poly": [[5, 9.5, 85.5], [5, 33.25, 61.75], [0, 35, 65], [0, 10, 90]]},
+        "tonalite": {
+            "name": "Tonalite",
+            "poly": [[60, 4, 36], [60, 0, 40], [20, 0, 80], [20, 8, 72]]},
+        "quart-diorite": {
+            "name": "Quartz Diorite/Gabbro/Anorthosite",
+            "poly": [[20, 8, 72], [20, 0, 80], [5, 0, 95], [5, 9.5, 85.5]]},
+        "diorite-gabbro-anorthosite": {
+            "name": "Diorite/Gabbro/Anorthosite",
+            "poly": [[5, 9.5, 85.5], [5, 0, 95], [0, 0, 100], [0, 10, 90]]},
+        "granite": {
+            "name": "Granite",
+            "poly": [[60, 36, 4], [60, 14, 26], [20, 28, 52], [20, 72, 8]]}
+    }
+}

--- a/pyrolite/plot/templates/QAP.py
+++ b/pyrolite/plot/templates/QAP.py
@@ -1,0 +1,46 @@
+import matplotlib.pyplot as plt
+import numpy as np
+from ...util.plot.axes import init_axes
+from ...util.classification import QAP as QAP
+from ...util.meta import sphinx_doi_link, update_docstring_references, subkwargs
+from ...util.log import Handle
+
+logger = Handle(__name__)
+
+
+@update_docstring_references
+def QAP(ax=None, add_labels=False, color="k", **kwargs):
+    """
+    IUGS QAP ternary classification
+    [#ref_1]_ [#ref_2]_.
+
+    Parameters
+    -----------
+    name : :class:`str`
+        A name for the classifier model.
+    axes : :class:`list` | :class:`tuple`
+        Names of the axes corresponding to the polygon coordinates.
+    fields : :class:`dict`
+        Dictionary describing indiviudal polygons, with identifiers as keys and
+        dictionaries containing 'name' and 'fields' items.
+
+    References
+    -----------
+}    .. [#ref_1] Streckeisen, A. Classification and nomenclature of plutonic rocks
+                recommendations of the IUGS subcommission on the systematics of
+                Igneous Rocks. Geol Rundsch 63, 773–786 (1974).
+                doi: {Streckeisen1974}
+    .. [#ref_2] Le Maitre,R.W. 2002. Igneous Rocks: A Classification and Glossary
+                of Terms : Recommendations of International Union of Geological
+                Sciences Subcommission on the Systematics of Igneous Rocks.
+                Cambridge University Press, 236pp
+    """
+    ax = init_axes(ax=ax, **kwargs)
+    clf = QAP()
+    clf.add_to_axes(ax=ax, color=color, add_labels=add_labels, **kwargs)
+    return ax
+
+
+QAP.__doc__ = QAP.__doc__.format(
+    Streckeisen1974=sphinx_doi_link("10.1007/BF01820841")
+)

--- a/pyrolite/plot/templates/QAP.py
+++ b/pyrolite/plot/templates/QAP.py
@@ -26,7 +26,7 @@ def QAP(ax=None, add_labels=False, color="k", **kwargs):
 
     References
     -----------
-}    .. [#ref_1] Streckeisen, A. Classification and nomenclature of plutonic rocks
+    .. [#ref_1] Streckeisen, A. Classification and nomenclature of plutonic rocks
                 recommendations of the IUGS subcommission on the systematics of
                 Igneous Rocks. Geol Rundsch 63, 773–786 (1974).
                 doi: {Streckeisen1974}

--- a/pyrolite/plot/templates/__init__.py
+++ b/pyrolite/plot/templates/__init__.py
@@ -9,8 +9,9 @@ Todo
 from .pearce import pearceThNbYb, pearceTiNbYb
 from .TAS import TAS
 from .USDA_soil_texture import USDASoilTexture
+from .QAP import QAP
 from ...util.log import Handle
 
 logger = Handle(__name__)
 
-__all__ = ["pearceThNbYb", "pearceTiNbYb", "TAS", USDASoilTexture]
+__all__ = ["pearceThNbYb", "pearceTiNbYb", "TAS", USDASoilTexture, "QAP"]

--- a/pyrolite/util/classification.py
+++ b/pyrolite/util/classification.py
@@ -417,7 +417,7 @@ class QAP(PolygonClassifier):
 
     References
     -----------
-}    .. [#ref_1] Streckeisen, A. Classification and nomenclature of plutonic rocks
+    .. [#ref_1] Streckeisen, A. Classification and nomenclature of plutonic rocks
                 recommendations of the IUGS subcommission on the systematics of
                 Igneous Rocks. Geol Rundsch 63, 773–786 (1974).
                 https://doi.org/10.1007/BF01820841

--- a/pyrolite/util/classification.py
+++ b/pyrolite/util/classification.py
@@ -400,6 +400,46 @@ class USDASoilTexture(PolygonClassifier):
         super().__init__(**poly_config)
 
 
+class QAP(PolygonClassifier):
+    """
+    IUGS QAP ternary classification
+    [#ref_1]_ [#ref_2]_.
+
+    Parameters
+    -----------
+    name : :class:`str`
+        A name for the classifier model.
+    axes : :class:`list` | :class:`tuple`
+        Names of the axes corresponding to the polygon coordinates.
+    fields : :class:`dict`
+        Dictionary describing indiviudal polygons, with identifiers as keys and
+        dictionaries containing 'name' and 'fields' items.
+
+    References
+    -----------
+}    .. [#ref_1] Streckeisen, A. Classification and nomenclature of plutonic rocks
+                recommendations of the IUGS subcommission on the systematics of
+                Igneous Rocks. Geol Rundsch 63, 773–786 (1974).
+                https://doi.org/10.1007/BF01820841
+    .. [#ref_2] Le Maitre,R.W. 2002. Igneous Rocks: A Classification and Glossary
+                of Terms : Recommendations of International Union of Geological
+                Sciences Subcommission on the Systematics of Igneous Rocks.
+                Cambridge University Press, 236pp
+    """
+
+    @update_docstring_references
+    def __init__(self, **kwargs):
+        src = (
+            pyrolite_datafolder(subfolder="models") / "QAP" / "config.json"
+        )
+
+        with open(src, "r") as f:
+            config = json.load(f)
+
+        poly_config = {**config, **kwargs, "transform": "ternary"}
+        super().__init__(**poly_config)
+
+
 class PeralkalinityClassifier(object):
     def __init__(self):
         self.fields = None


### PR DESCRIPTION
This sets up the classifier for a QAP diagram. Most of the details are copied from the existing USDA soil classifier, but modified.

The polygons are in the right locations, but need to still be tested with some sample data to ensure that the classification is working as expected.

The unusual presentation of the standard QAP ternary compared to a normal one probably needs to be called out in the docs as well, which I have not done yet.

Creating the PR early in case there are changes that you would like to see in terms of style and similar.

## Description
<!--- Describe your changes in detail -->
Added `QAP` as a new classifier in `util.classifier`.

## Related Issue
This should close #49 with there being a couple of examples in the code.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is just an extra example of a commonly-used geological classifier that may be useful for people.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
