### PR TITLE
dropped columns from FREE df that are not required

### DIFF
--- a/pyrolite/mineral/normative.py
+++ b/pyrolite/mineral/normative.py
@@ -1214,6 +1214,8 @@ def CIPW_norm(
         ["FREEO_12b", "FREEO_12c", "FREEO_13", "FREEO_14", "FREEO_16"]
     ].sum(axis=1)
 
+    FREE.drop(["FREEO_12b", "FREEO_12c", "FREEO_13", "FREEO_14", "FREEO_16"], axis=1, inplace=True)
+
     ############################################################################
     # get masses of free components
     ############################################################################


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Dropped the components that are summed to form FREE_O in the FREE df, as they are not required and were being returned

## Related Issue
https://github.com/morganjwilliams/pyrolite/issues/53

## Motivation and Context
removes unnecessary outputs from norm function

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
