### PR TITLE
retain original ax labels in TAS example

### DIFF
--- a/docs/source/gallery/examples/util/TAS.py
+++ b/docs/source/gallery/examples/util/TAS.py
@@ -30,14 +30,13 @@ df.head(3)
 ########################################################################################
 # We can visualise how this chemistry corresponds to the TAS diagram:
 #
-import pyrolite.plot
 
 df["Na2O + K2O"] = df["Na2O"] + df["K2O"]
 cm = TAS()
 
 fig, ax = plt.subplots(1)
 cm.add_to_axes(ax, alpha=0.5, linewidth=0.5, zorder=-1, add_labels=True)
-df[["SiO2", "Na2O + K2O"]].pyroplot.scatter(ax=ax, c="k", alpha=0.2)
+df[["SiO2", "Na2O + K2O"]].pyroplot.scatter(ax=ax, c="k", alpha=0.2, axlabels=False)
 plt.show()
 ########################################################################################
 # We can now classify this data according to the fields of the TAS diagram, and
@@ -56,7 +55,7 @@ df["Rocknames"].sample(10)  # randomly check 10 sample rocknames
 fig, ax = plt.subplots(1)
 
 cm.add_to_axes(ax, alpha=0.5, linewidth=0.5, zorder=-1, add_labels=True)
-df[["SiO2", "Na2O + K2O"]].pyroplot.scatter(ax=ax, c=df["TAS"], alpha=0.7)
+df[["SiO2", "Na2O + K2O"]].pyroplot.scatter(ax=ax, c=df["TAS"], alpha=0.7, axlabels=False)
 
 ########################################################################################
 # Variations of the Diagram


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR ensures the intended formatting of the x and y-axis labels in the TAS plot example. It also removes an unused import.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
