### PR TITLE
added option to plot at visual center of fields

### DIFF
--- a/docs/source/dev/contributors.rst
+++ b/docs/source/dev/contributors.rst
@@ -21,3 +21,4 @@ comments, testing, bug reports, or feature requests.
 * `Angela Rodrigues <https://github.com/AngRodrigues>`__
 * `Sarah Shi <https://github.com/sarahshi>`__
 * `Ondrej Lexa <https://github.com/ondrolexa>`__
+* `Bob Myhill <https://github.com/bobmyhill>`__

--- a/docs/source/gallery/examples/plotting/parallel.py
+++ b/docs/source/gallery/examples/plotting/parallel.py
@@ -8,6 +8,7 @@ a handy quick exploratory visualisation.
 """
 import matplotlib.axes
 import matplotlib.pyplot as plt
+from mpl_toolkits.axes_grid1 import make_axes_locatable
 import numpy as np
 import pandas as pd
 
@@ -42,15 +43,19 @@ cmap = "inferno"
 compdata = df.copy()
 compdata[comp] = CLRTransform().transform(compdata[comp])
 ax = compdata.loc[:, comp].pyroplot.parallel(color_by=compdata.Depth.values, cmap=cmap)
+divider = make_axes_locatable(ax)
+cax = divider.append_axes('right', size='5%', pad=0.05)
 
 # we can add a meaningful colorbar to indicate one variable also, here Depth
 sm = plt.cm.ScalarMappable(cmap=cmap)
 sm.set_array(df.Depth)
-plt.colorbar(sm)
+plt.colorbar(sm, cax=cax, orientation='vertical')
 plt.show()
 ########################################################################################
 ax = compdata.loc[:, comp].pyroplot.parallel(
     rescale=True, color_by=compdata.Depth.values, cmap=cmap
 )
-plt.colorbar(sm)
+divider = make_axes_locatable(ax)
+cax = divider.append_axes('right', size='5%', pad=0.05)
+plt.colorbar(sm, cax=cax, orientation='vertical')
 plt.show()

--- a/docs/source/gallery/examples/plotting/parallel.py
+++ b/docs/source/gallery/examples/plotting/parallel.py
@@ -42,7 +42,7 @@ from pyrolite.util.skl.transform import CLRTransform
 cmap = "inferno"
 compdata = df.copy()
 compdata[comp] = CLRTransform().transform(compdata[comp])
-ax = compdata.loc[:, comp].pyroplot.parallel(color_by=compdata.Depth.values, cmap=cmap)
+ax = compdata.loc[:, comp].pyroplot.parallel(color=compdata.Depth.values, cmap=cmap)
 divider = make_axes_locatable(ax)
 cax = divider.append_axes('right', size='5%', pad=0.05)
 
@@ -53,7 +53,7 @@ plt.colorbar(sm, cax=cax, orientation='vertical')
 plt.show()
 ########################################################################################
 ax = compdata.loc[:, comp].pyroplot.parallel(
-    rescale=True, color_by=compdata.Depth.values, cmap=cmap
+    rescale=True, color=compdata.Depth.values, cmap=cmap
 )
 divider = make_axes_locatable(ax)
 cax = divider.append_axes('right', size='5%', pad=0.05)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ dependencies = [
     "sympy>=1.7",
     "pandas>=1.0",    # dataframe acccessors, attrs attribute
     "requests",       # used by alphaMELTS utilities,  util.web
-    "python-polylabel", # used to find visual center of polygons
 ]
 
 [tool.setuptools.packages]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "sympy>=1.7",
     "pandas>=1.0",    # dataframe acccessors, attrs attribute
     "requests",       # used by alphaMELTS utilities,  util.web
+    "python-polylabel", # used to find visual center of polygons
 ]
 
 [tool.setuptools.packages]

--- a/pyrolite/geochem/transform.py
+++ b/pyrolite/geochem/transform.py
@@ -349,10 +349,7 @@ def aggregate_element(
 
     if logdata:
         logger.debug("Log-transforming {} Data.".format(cation))
-        try:
-            _df.loc[:, targetnames] = _df.loc[:, targetnames].map(np.log)
-        except AttributeError:  # can remove when Python 3.8 is no longer supported
-            _df.loc[:, targetnames] = _df.loc[:, targetnames].applymap(np.log)
+        _df.loc[:, targetnames] = np.log(_df.loc[:, targetnames])
     if drop:
         logger.debug("Dropping redundant columns: {}".format(", ".join(drop)))
         df = df.drop(columns=drop)

--- a/pyrolite/geochem/transform.py
+++ b/pyrolite/geochem/transform.py
@@ -349,7 +349,7 @@ def aggregate_element(
 
     if logdata:
         logger.debug("Log-transforming {} Data.".format(cation))
-        _df.loc[:, targetnames] = _df.loc[:, targetnames].applymap(np.log)
+        _df.loc[:, targetnames] = _df.loc[:, targetnames].map(np.log)
 
     if drop:
         logger.debug("Dropping redundant columns: {}".format(", ".join(drop)))

--- a/pyrolite/geochem/transform.py
+++ b/pyrolite/geochem/transform.py
@@ -349,8 +349,10 @@ def aggregate_element(
 
     if logdata:
         logger.debug("Log-transforming {} Data.".format(cation))
-        _df.loc[:, targetnames] = _df.loc[:, targetnames].map(np.log)
-
+        try:
+            _df.loc[:, targetnames] = _df.loc[:, targetnames].map(np.log)
+        except AttributeError:  # can remove when Python 3.8 is no longer supported
+            _df.loc[:, targetnames] = _df.loc[:, targetnames].applymap(np.log)
     if drop:
         logger.debug("Dropping redundant columns: {}".format(", ".join(drop)))
         df = df.drop(columns=drop)

--- a/pyrolite/plot/spider.py
+++ b/pyrolite/plot/spider.py
@@ -218,7 +218,7 @@ def spider(
     elif any([i in mode.lower() for i in ["binkde", "ckde", "kde", "hist"]]):
         cmap = kwargs.pop("cmap", None)
         if "contours" in kwargs and "vmin" in kwargs:
-            msg = "Combining `contours` and `vmin` arugments for density plots should be avoided."
+            msg = "Combining `contours` and `vmin` arguments for density plots should be avoided."
             logger.warn(msg)
         xe, ye, zi, xi, yi = conditional_prob_density(
             arr,

--- a/pyrolite/plot/spider.py
+++ b/pyrolite/plot/spider.py
@@ -160,7 +160,7 @@ def spider(
         # if a color option is not specified, get the next cycled color
         if l_kw.get("color") is None:
             # add cycler color as array to suppress singular color warning
-            l_kw["color"] = np.array([next(ax._get_lines.prop_cycler)["color"]])
+            l_kw["color"] = ax._get_lines.get_next_color()
 
         l_kw = linekwargs(process_color(**{**_line_defaults, **l_kw}))
         # marker explictly dealt with by scatter
@@ -209,7 +209,7 @@ def spider(
             )
             # do these need to be ravelled?
             ax.scatter(
-                indexes.ravel(), arr.ravel(), c=scattercolor, **{"zorder": 2, **s_kw}
+                indexes.ravel(), arr.ravel(), color=scattercolor, **{"zorder": 2, **s_kw}
             )
 
         # should create a custom legend handle here

--- a/pyrolite/util/plot/center.py
+++ b/pyrolite/util/plot/center.py
@@ -1,0 +1,175 @@
+"""
+Functions for calculating the visual center of a polygon.
+Taken from https://github.com/Twista/python-polylabel,
+Originally released under an MIT licence.
+"""
+from math import sqrt, inf
+import time
+from queue import PriorityQueue
+
+
+def _point_to_polygon_distance(x, y, polygon):
+    inside = False
+    min_dist_sq = inf
+
+    for ring in polygon:
+        b = ring[-1]
+        for a in ring:
+
+            if ((a[1] > y) != (b[1] > y) and
+                    (x < (b[0] - a[0]) * (y - a[1]) / (b[1] - a[1]) + a[0])):
+                inside = not inside
+
+            min_dist_sq = min(min_dist_sq, _get_seg_dist_sq(x, y, a, b))
+            b = a
+
+    result = sqrt(min_dist_sq)
+    if not inside:
+        return -result
+    return result
+
+
+def _get_seg_dist_sq(px, py, a, b):
+    x = a[0]
+    y = a[1]
+    dx = b[0] - x
+    dy = b[1] - y
+
+    if dx != 0 or dy != 0:
+        t = ((px - x) * dx + (py - y) * dy) / (dx * dx + dy * dy)
+
+        if t > 1:
+            x = b[0]
+            y = b[1]
+
+        elif t > 0:
+            x += dx * t
+            y += dy * t
+
+    dx = px - x
+    dy = py - y
+
+    return dx * dx + dy * dy
+
+
+class Cell(object):
+    def __init__(self, x, y, h, polygon):
+        self.h = h
+        self.y = y
+        self.x = x
+        self.d = _point_to_polygon_distance(x, y, polygon)
+        self.max = self.d + self.h * sqrt(2)
+
+    def __lt__(self, other):
+        return self.max < other.max
+
+    def __lte__(self, other):
+        return self.max <= other.max
+
+    def __gt__(self, other):
+        return self.max > other.max
+
+    def __gte__(self, other):
+        return self.max >= other.max
+
+    def __eq__(self, other):
+        return self.max == other.max
+
+
+def _get_centroid_cell(polygon):
+    area = 0
+    x = 0
+    y = 0
+    points = polygon[0]
+    b = points[-1]  # prev
+    for a in points:
+        f = a[0] * b[1] - b[0] * a[1]
+        x += (a[0] + b[0]) * f
+        y += (a[1] + b[1]) * f
+        area += f * 3
+        b = a
+    if area == 0:
+        return Cell(points[0][0], points[0][1], 0, polygon)
+    return Cell(x / area, y / area, 0, polygon)
+
+    pass
+
+
+def visual_center(polygon, precision=1.0, debug=False, with_distance=False):
+    # find bounding box
+    first_item = polygon[0][0]
+    min_x = first_item[0]
+    min_y = first_item[1]
+    max_x = first_item[0]
+    max_y = first_item[1]
+    for p in polygon[0]:
+        if p[0] < min_x:
+            min_x = p[0]
+        if p[1] < min_y:
+            min_y = p[1]
+        if p[0] > max_x:
+            max_x = p[0]
+        if p[1] > max_y:
+            max_y = p[1]
+
+    width = max_x - min_x
+    height = max_y - min_y
+    cell_size = min(width, height)
+    h = cell_size / 2.0
+
+    cell_queue = PriorityQueue()
+
+    if cell_size == 0:
+        if with_distance:
+            return [min_x, min_y], None
+        else:
+            return [min_x, min_y]
+
+    # cover polygon with initial cells
+    x = min_x
+    while x < max_x:
+        y = min_y
+        while y < max_y:
+            c = Cell(x + h, y + h, h, polygon)
+            y += cell_size
+            cell_queue.put((-c.max, time.time(), c))
+        x += cell_size
+
+    best_cell = _get_centroid_cell(polygon)
+
+    bbox_cell = Cell(min_x + width / 2, min_y + height / 2, 0, polygon)
+    if bbox_cell.d > best_cell.d:
+        best_cell = bbox_cell
+
+    num_of_probes = cell_queue.qsize()
+    while not cell_queue.empty():
+        _, __, cell = cell_queue.get()
+
+        if cell.d > best_cell.d:
+            best_cell = cell
+
+            if debug:
+                print('found best {} after {} probes'.format(
+                    round(1e4 * cell.d) / 1e4, num_of_probes))
+
+        if cell.max - best_cell.d <= precision:
+            continue
+
+        h = cell.h / 2
+        c = Cell(cell.x - h, cell.y - h, h, polygon)
+        cell_queue.put((-c.max, time.time(), c))
+        c = Cell(cell.x + h, cell.y - h, h, polygon)
+        cell_queue.put((-c.max, time.time(), c))
+        c = Cell(cell.x - h, cell.y + h, h, polygon)
+        cell_queue.put((-c.max, time.time(), c))
+        c = Cell(cell.x + h, cell.y + h, h, polygon)
+        cell_queue.put((-c.max, time.time(), c))
+        num_of_probes += 4
+
+    if debug:
+        print('num probes: {}'.format(num_of_probes))
+        print('best distance: {}'.format(best_cell.d))
+    if with_distance:
+        return [best_cell.x, best_cell.y], best_cell.d
+    else:
+        return [best_cell.x, best_cell.y]

--- a/pyrolite/util/plot/helpers.py
+++ b/pyrolite/util/plot/helpers.py
@@ -5,6 +5,7 @@ import matplotlib.patches
 import matplotlib.pyplot as plt
 import numpy as np
 import scipy.spatial
+from polylabel import polylabel
 
 from ..log import Handle
 from ..math import eigsorted, nancov
@@ -76,6 +77,30 @@ def get_centroid(poly):
     cx /= 6 * A
     cy /= 6 * A
     return cx, cy
+
+
+def get_visual_center(poly, vertical_exaggeration=1):
+    """
+    Visual center of a closed polygon using the polylabel python module.
+
+    Parameters
+    ----------
+    poly : :class:`matplotlib.patches.Polygon`
+        Polygon for which to obtain the visual center.
+
+    vertical_exaggeration : :class:`float`
+        Apparent vertical exaggeration of the plot
+        (pixels per unit in y direction divided by pixels 
+        per unit in the x direction).
+
+    Returns
+    -------
+    cx, cy : :class:`tuple`
+        Centroid coordinates.
+    """
+    poly_scaled = np.array([poly.get_xy() * [1., vertical_exaggeration]])
+    x, y = polylabel(poly_scaled)
+    return tuple([x, y/vertical_exaggeration])
 
 
 def rect_from_centre(x, y, dx=0, dy=0, **kwargs):

--- a/pyrolite/util/plot/helpers.py
+++ b/pyrolite/util/plot/helpers.py
@@ -5,7 +5,7 @@ import matplotlib.patches
 import matplotlib.pyplot as plt
 import numpy as np
 import scipy.spatial
-from polylabel import polylabel
+from .center import visual_center
 
 from ..log import Handle
 from ..math import eigsorted, nancov
@@ -81,7 +81,7 @@ def get_centroid(poly):
 
 def get_visual_center(poly, vertical_exaggeration=1):
     """
-    Visual center of a closed polygon using the polylabel python module.
+    Visual center of a closed polygon.
 
     Parameters
     ----------
@@ -99,7 +99,7 @@ def get_visual_center(poly, vertical_exaggeration=1):
         Centroid coordinates.
     """
     poly_scaled = np.array([poly.get_xy() * [1., vertical_exaggeration]])
-    x, y = polylabel(poly_scaled)
+    x, y = visual_center(poly_scaled)
     return tuple([x, y/vertical_exaggeration])
 
 

--- a/pyrolite/util/skl/transform.py
+++ b/pyrolite/util/skl/transform.py
@@ -78,10 +78,7 @@ class ExpTransform(BaseEstimator, TransformerMixin):
 
     def transform(self, X, *args, **kwargs):
         if isinstance(X, pd.DataFrame):
-            try:
-                out = X.map(self.forward)
-            except AttributeError:  # can remove when Python 3.8 is no longer supported
-                out = X.applymap(self.forward)
+            out = self.forward(X)
         elif isinstance(X, pd.Series):
             out = X.apply(self.forward)
         else:
@@ -90,10 +87,7 @@ class ExpTransform(BaseEstimator, TransformerMixin):
 
     def inverse_transform(self, Y, *args, **kwargs):
         if isinstance(Y, pd.DataFrame):
-            try:
-                out = Y.map(self.inverse)
-            except AttributeError:  # can remove when Python 3.8 is no longer supported
-                out = Y.applymap(self.inverse)
+            out = self.inverse(Y)
         elif isinstance(Y, pd.Series):
             out = Y.apply(self.inverse)
         else:

--- a/pyrolite/util/skl/transform.py
+++ b/pyrolite/util/skl/transform.py
@@ -78,7 +78,7 @@ class ExpTransform(BaseEstimator, TransformerMixin):
 
     def transform(self, X, *args, **kwargs):
         if isinstance(X, pd.DataFrame):
-            out = X.applymap(self.forward)
+            out = X.map(self.forward)
         elif isinstance(X, pd.Series):
             out = X.apply(self.forward)
         else:
@@ -87,7 +87,7 @@ class ExpTransform(BaseEstimator, TransformerMixin):
 
     def inverse_transform(self, Y, *args, **kwargs):
         if isinstance(Y, pd.DataFrame):
-            out = Y.applymap(self.inverse)
+            out = Y.map(self.inverse)
         elif isinstance(Y, pd.Series):
             out = Y.apply(self.inverse)
         else:

--- a/pyrolite/util/skl/transform.py
+++ b/pyrolite/util/skl/transform.py
@@ -78,7 +78,10 @@ class ExpTransform(BaseEstimator, TransformerMixin):
 
     def transform(self, X, *args, **kwargs):
         if isinstance(X, pd.DataFrame):
-            out = X.map(self.forward)
+            try:
+                out = X.map(self.forward)
+            except AttributeError:  # can remove when Python 3.8 is no longer supported
+                out = X.applymap(self.forward)
         elif isinstance(X, pd.Series):
             out = X.apply(self.forward)
         else:
@@ -87,7 +90,10 @@ class ExpTransform(BaseEstimator, TransformerMixin):
 
     def inverse_transform(self, Y, *args, **kwargs):
         if isinstance(Y, pd.DataFrame):
-            out = Y.map(self.inverse)
+            try:
+                out = Y.map(self.inverse)
+            except AttributeError:  # can remove when Python 3.8 is no longer supported
+                out = Y.applymap(self.inverse)
         elif isinstance(Y, pd.Series):
             out = Y.apply(self.inverse)
         else:

--- a/pyrolite/util/synthetic.py
+++ b/pyrolite/util/synthetic.py
@@ -312,7 +312,7 @@ def example_spider_data(
     df = ref.comp.pyrochem.compositional
     if norm_to is not None:
         df = df.pyrochem.normalize_to(norm_to, units=units)
-    start = df.applymap(np.log)
+    start = df.map(np.log)
     nindex = df.columns.size
 
     y = np.tile(start.values, size).reshape(size, nindex)
@@ -323,7 +323,7 @@ def example_spider_data(
     if offsets is not None:
         for element, offset in offsets.items():
             syn_df[element] += offset  # significant offset for e.g. Eu anomaly
-    syn_df = syn_df.applymap(np.exp)
+    syn_df = syn_df.map(np.exp)
     return syn_df
 
 

--- a/pyrolite/util/synthetic.py
+++ b/pyrolite/util/synthetic.py
@@ -312,10 +312,7 @@ def example_spider_data(
     df = ref.comp.pyrochem.compositional
     if norm_to is not None:
         df = df.pyrochem.normalize_to(norm_to, units=units)
-    try:
-        start = df.map(np.log)
-    except AttributeError:  # can remove when Python 3.8 is no longer supported
-        start = df.applymap(np.log)
+    start = np.log(df)
     nindex = df.columns.size
 
     y = np.tile(start.values, size).reshape(size, nindex)
@@ -326,10 +323,7 @@ def example_spider_data(
     if offsets is not None:
         for element, offset in offsets.items():
             syn_df[element] += offset  # significant offset for e.g. Eu anomaly
-    try:
-        syn_df = syn_df.map(np.exp)
-    except AttributeError:  # can remove when Python 3.8 is no longer supported
-        syn_df = syn_df.applymap(np.exp)
+    syn_df = np.exp(syn_df)
     return syn_df
 
 

--- a/pyrolite/util/synthetic.py
+++ b/pyrolite/util/synthetic.py
@@ -312,7 +312,10 @@ def example_spider_data(
     df = ref.comp.pyrochem.compositional
     if norm_to is not None:
         df = df.pyrochem.normalize_to(norm_to, units=units)
-    start = df.map(np.log)
+    try:
+        start = df.map(np.log)
+    except AttributeError:  # can remove when Python 3.8 is no longer supported
+        start = df.applymap(np.log)
     nindex = df.columns.size
 
     y = np.tile(start.values, size).reshape(size, nindex)
@@ -323,7 +326,10 @@ def example_spider_data(
     if offsets is not None:
         for element, offset in offsets.items():
             syn_df[element] += offset  # significant offset for e.g. Eu anomaly
-    syn_df = syn_df.map(np.exp)
+    try:
+        syn_df = syn_df.map(np.exp)
+    except AttributeError:  # can remove when Python 3.8 is no longer supported
+        syn_df = syn_df.applymap(np.exp)
     return syn_df
 
 

--- a/test/util/plot/util_plot_density.py
+++ b/test/util/plot/util_plot_density.py
@@ -60,7 +60,7 @@ class TestPlotZPercentiles(unittest.TestCase):
         cs = plot_Z_percentiles(
             self.xi, self.yi, zi=self.zi, contour_labels=contour_labels
         )
-        for contour_label, label in zip(contour_labels, cs.labelTextsList):
+        for contour_label, label in zip(contour_labels, cs.labelTexts):
             label = label.get_text()
             self.assertTrue(contour_label == label)
 
@@ -80,12 +80,17 @@ class TestPlotZPercentiles(unittest.TestCase):
             linestyles=linestyles,
             linewidths=linewidths,
         )
-        for contour, color, ls, lw in zip(
-            cs.collections, colors, linestyles, linewidths
-        ):
-            self.assertTrue((contour.get_edgecolor() == color).all())
-            self.assertEqual(contour.get_linestyle(), [_scale_dashes(*ls, lw)])
-            self.assertEqual(contour.get_linewidth(), lw)
+        try:
+            self.assertTrue(cs.colors == colors)
+            self.assertTrue(cs.linestyles == linestyles)
+            self.assertTrue((cs._us_lw == linewidths).all())
+        except AttributeError:  # matplotlib version < 3.8
+            for contour, color, ls, lw in zip(
+                cs.collections, colors, linestyles, linewidths
+            ):
+                self.assertTrue((contour.get_edgecolor() == color).all())
+                self.assertEqual(contour.get_linestyle(), [_scale_dashes(*ls, lw)])
+                self.assertEqual(contour.get_linewidth(), lw)
 
     def test_linestyles_specified(self):
         plot_Z_percentiles(

--- a/test/util/util_classification.py
+++ b/test/util/util_classification.py
@@ -1,10 +1,13 @@
 import unittest
-
 import matplotlib.pyplot as plt
-import numpy as np
+import pandas as pd
 
-from pyrolite.comp.codata import renormalise
-from pyrolite.util.classification import *
+from pyrolite.util.classification import (TAS,
+                                          USDASoilTexture,
+                                          QAP,
+                                          FeldsparTernary,
+                                          JensenPlot,
+                                          PeralkalinityClassifier)
 from pyrolite.util.synthetic import normal_frame, random_cov_matrix
 
 
@@ -20,29 +23,31 @@ class TestTAS(unittest.TestCase):
         self.df.loc[:, "Na2O + K2O"] = self.df.Na2O + self.df.K2O
 
     def test_classifer_build(self):
-        cm = TAS()
+        _ = TAS()
 
     def test_classifer_add_to_axes(self):
         cm = TAS()
-        fig, ax = plt.subplots(1)
+        _, ax = plt.subplots(1)
         for a in [None, ax]:
-            with self.subTest(a=a):
-                cm.add_to_axes(
-                    ax=a,
-                    alpha=0.4,
-                    color="k",
-                    axes_scale=100,
-                    linewidth=0.5,
-                    which_labels="ID",
-                    add_labels=True,
-                )
+            for label_at_centroid in [True, False]:
+                with self.subTest(a=a):
+                    cm.add_to_axes(
+                        ax=a,
+                        alpha=0.4,
+                        color="k",
+                        axes_scale=100,
+                        linewidth=0.5,
+                        which_labels="ID",
+                        add_labels=True,
+                        label_at_centroid=label_at_centroid,
+                    )
 
     def test_classifer_predict(self):
         df = self.df
         cm = TAS()
         classes = cm.predict(df, data_scale=1.0)
-        # precitions will be ID's
-        rocknames = classes.apply(lambda x: cm.fields.get(x, {"name": None})["name"])
+        # rocknames will be IDs
+        _ = classes.apply(lambda x: cm.fields.get(x, {"name": None})["name"])
         self.assertFalse(pd.isnull(classes).all())
 
 
@@ -55,7 +60,7 @@ class TestUSDASoilTexture(unittest.TestCase):
         )
 
     def test_classifer_build(self):
-        cm = USDASoilTexture()
+        _ = USDASoilTexture()
 
     def test_classifer_add_to_axes(self):
         cm = USDASoilTexture()
@@ -82,7 +87,7 @@ class TestQAP(unittest.TestCase):
         )
 
     def test_classifer_build(self):
-        cm = QAP()
+        _ = QAP()
 
     def test_classifer_add_to_axes(self):
         cm = QAP()
@@ -109,11 +114,11 @@ class TestFeldsparTernary(unittest.TestCase):
         )
 
     def test_classifer_build(self):
-        cm = FeldsparTernary()
+        _ = FeldsparTernary()
 
     def test_classifer_add_to_axes(self):
         cm = FeldsparTernary()
-        fig, ax = plt.subplots(1)
+        _, ax = plt.subplots(1)
         for a in [None, ax]:
             with self.subTest(a=a):
                 cm.add_to_axes(
@@ -137,11 +142,11 @@ class TestJensenPlot(unittest.TestCase):
         )
 
     def test_classifer_build(self):
-        cm = JensenPlot()
+        _ = JensenPlot()
 
     def test_classifer_add_to_axes(self):
         cm = JensenPlot()
-        fig, ax = plt.subplots(1)
+        _, ax = plt.subplots(1)
         for a in [None, ax]:
             with self.subTest(a=a):
                 cm.add_to_axes(
@@ -159,7 +164,7 @@ class TestPeralkalinity(unittest.TestCase):
     """Test the peralkalinity classifier."""
 
     def setUp(self):
-        self.df = df = normal_frame(
+        self.df = normal_frame(
             columns=["SiO2", "Na2O", "K2O", "Al2O3", "CaO"],
             mean=[0.5, 0.04, 0.05, 0.2, 0.3],
             size=100,

--- a/test/util/util_pd.py
+++ b/test/util/util_pd.py
@@ -123,7 +123,10 @@ class TestToSer(unittest.TestCase):
 
 class TestToNumeric(unittest.TestCase):
     def setUp(self):
-        self.df = normal_frame().applymap(str)
+        try:
+            self.df = normal_frame().map(str)
+        except AttributeError:
+            self.df = normal_frame().applymap(str)
 
     def test_numeric(self):
         df = self.df

--- a/test/util/util_pd.py
+++ b/test/util/util_pd.py
@@ -123,10 +123,7 @@ class TestToSer(unittest.TestCase):
 
 class TestToNumeric(unittest.TestCase):
     def setUp(self):
-        try:
-            self.df = normal_frame().map(str)
-        except AttributeError:
-            self.df = normal_frame().applymap(str)
+        self.df = normal_frame().astype(str)
 
     def test_numeric(self):
         df = self.df


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds the option to plot field labels at the "visual center" of a field, rather than the centroid. The "visual center" is defined as the center of the largest inscribed circle. An option is provided to pass a vertical exaggeration, which instead finds the center of the largest inscribed ellipse.

Builds on #96.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
For fields with reflex boundary vertices ("concave polygons"), the centroid can plot close to a boundary or even outside the field. The "visual center" of a polygon is often a better location for field labels.

@morganjwilliams: I'm not sure whether this is something you want in the code, but I needed it anyway, so thought I'd open the PR.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
