### PR TITLE
[FIX] Modernise some matplotlib calls

### DIFF
--- a/docs/source/dev/contributors.rst
+++ b/docs/source/dev/contributors.rst
@@ -21,3 +21,4 @@ comments, testing, bug reports, or feature requests.
 * `Angela Rodrigues <https://github.com/AngRodrigues>`__
 * `Sarah Shi <https://github.com/sarahshi>`__
 * `Ondrej Lexa <https://github.com/ondrolexa>`__
+* `Bob Myhill <https://github.com/bobmyhill>`__

--- a/docs/source/gallery/examples/plotting/parallel.py
+++ b/docs/source/gallery/examples/plotting/parallel.py
@@ -8,6 +8,7 @@ a handy quick exploratory visualisation.
 """
 import matplotlib.axes
 import matplotlib.pyplot as plt
+from mpl_toolkits.axes_grid1 import make_axes_locatable
 import numpy as np
 import pandas as pd
 
@@ -42,15 +43,19 @@ cmap = "inferno"
 compdata = df.copy()
 compdata[comp] = CLRTransform().transform(compdata[comp])
 ax = compdata.loc[:, comp].pyroplot.parallel(color_by=compdata.Depth.values, cmap=cmap)
+divider = make_axes_locatable(ax)
+cax = divider.append_axes('right', size='5%', pad=0.05)
 
 # we can add a meaningful colorbar to indicate one variable also, here Depth
 sm = plt.cm.ScalarMappable(cmap=cmap)
 sm.set_array(df.Depth)
-plt.colorbar(sm)
+plt.colorbar(sm, cax=cax, orientation='vertical')
 plt.show()
 ########################################################################################
 ax = compdata.loc[:, comp].pyroplot.parallel(
     rescale=True, color_by=compdata.Depth.values, cmap=cmap
 )
-plt.colorbar(sm)
+divider = make_axes_locatable(ax)
+cax = divider.append_axes('right', size='5%', pad=0.05)
+plt.colorbar(sm, cax=cax, orientation='vertical')
 plt.show()

--- a/docs/source/gallery/examples/plotting/parallel.py
+++ b/docs/source/gallery/examples/plotting/parallel.py
@@ -42,7 +42,7 @@ from pyrolite.util.skl.transform import CLRTransform
 cmap = "inferno"
 compdata = df.copy()
 compdata[comp] = CLRTransform().transform(compdata[comp])
-ax = compdata.loc[:, comp].pyroplot.parallel(color_by=compdata.Depth.values, cmap=cmap)
+ax = compdata.loc[:, comp].pyroplot.parallel(color=compdata.Depth.values, cmap=cmap)
 divider = make_axes_locatable(ax)
 cax = divider.append_axes('right', size='5%', pad=0.05)
 
@@ -53,7 +53,7 @@ plt.colorbar(sm, cax=cax, orientation='vertical')
 plt.show()
 ########################################################################################
 ax = compdata.loc[:, comp].pyroplot.parallel(
-    rescale=True, color_by=compdata.Depth.values, cmap=cmap
+    rescale=True, color=compdata.Depth.values, cmap=cmap
 )
 divider = make_axes_locatable(ax)
 cax = divider.append_axes('right', size='5%', pad=0.05)

--- a/pyrolite/geochem/transform.py
+++ b/pyrolite/geochem/transform.py
@@ -349,10 +349,7 @@ def aggregate_element(
 
     if logdata:
         logger.debug("Log-transforming {} Data.".format(cation))
-        try:
-            _df.loc[:, targetnames] = _df.loc[:, targetnames].map(np.log)
-        except AttributeError:  # can remove when Python 3.8 is no longer supported
-            _df.loc[:, targetnames] = _df.loc[:, targetnames].applymap(np.log)
+        _df.loc[:, targetnames] = np.log(_df.loc[:, targetnames])
     if drop:
         logger.debug("Dropping redundant columns: {}".format(", ".join(drop)))
         df = df.drop(columns=drop)

--- a/pyrolite/geochem/transform.py
+++ b/pyrolite/geochem/transform.py
@@ -349,7 +349,7 @@ def aggregate_element(
 
     if logdata:
         logger.debug("Log-transforming {} Data.".format(cation))
-        _df.loc[:, targetnames] = _df.loc[:, targetnames].applymap(np.log)
+        _df.loc[:, targetnames] = _df.loc[:, targetnames].map(np.log)
 
     if drop:
         logger.debug("Dropping redundant columns: {}".format(", ".join(drop)))

--- a/pyrolite/geochem/transform.py
+++ b/pyrolite/geochem/transform.py
@@ -349,8 +349,10 @@ def aggregate_element(
 
     if logdata:
         logger.debug("Log-transforming {} Data.".format(cation))
-        _df.loc[:, targetnames] = _df.loc[:, targetnames].map(np.log)
-
+        try:
+            _df.loc[:, targetnames] = _df.loc[:, targetnames].map(np.log)
+        except AttributeError:  # can remove when Python 3.8 is no longer supported
+            _df.loc[:, targetnames] = _df.loc[:, targetnames].applymap(np.log)
     if drop:
         logger.debug("Dropping redundant columns: {}".format(", ".join(drop)))
         df = df.drop(columns=drop)

--- a/pyrolite/plot/spider.py
+++ b/pyrolite/plot/spider.py
@@ -218,7 +218,7 @@ def spider(
     elif any([i in mode.lower() for i in ["binkde", "ckde", "kde", "hist"]]):
         cmap = kwargs.pop("cmap", None)
         if "contours" in kwargs and "vmin" in kwargs:
-            msg = "Combining `contours` and `vmin` arugments for density plots should be avoided."
+            msg = "Combining `contours` and `vmin` arguments for density plots should be avoided."
             logger.warn(msg)
         xe, ye, zi, xi, yi = conditional_prob_density(
             arr,

--- a/pyrolite/plot/spider.py
+++ b/pyrolite/plot/spider.py
@@ -160,7 +160,7 @@ def spider(
         # if a color option is not specified, get the next cycled color
         if l_kw.get("color") is None:
             # add cycler color as array to suppress singular color warning
-            l_kw["color"] = np.array([next(ax._get_lines.prop_cycler)["color"]])
+            l_kw["color"] = ax._get_lines.get_next_color()
 
         l_kw = linekwargs(process_color(**{**_line_defaults, **l_kw}))
         # marker explictly dealt with by scatter
@@ -209,7 +209,7 @@ def spider(
             )
             # do these need to be ravelled?
             ax.scatter(
-                indexes.ravel(), arr.ravel(), c=scattercolor, **{"zorder": 2, **s_kw}
+                indexes.ravel(), arr.ravel(), color=scattercolor, **{"zorder": 2, **s_kw}
             )
 
         # should create a custom legend handle here

--- a/pyrolite/util/skl/transform.py
+++ b/pyrolite/util/skl/transform.py
@@ -78,10 +78,7 @@ class ExpTransform(BaseEstimator, TransformerMixin):
 
     def transform(self, X, *args, **kwargs):
         if isinstance(X, pd.DataFrame):
-            try:
-                out = X.map(self.forward)
-            except AttributeError:  # can remove when Python 3.8 is no longer supported
-                out = X.applymap(self.forward)
+            out = self.forward(X)
         elif isinstance(X, pd.Series):
             out = X.apply(self.forward)
         else:
@@ -90,10 +87,7 @@ class ExpTransform(BaseEstimator, TransformerMixin):
 
     def inverse_transform(self, Y, *args, **kwargs):
         if isinstance(Y, pd.DataFrame):
-            try:
-                out = Y.map(self.inverse)
-            except AttributeError:  # can remove when Python 3.8 is no longer supported
-                out = Y.applymap(self.inverse)
+            out = self.inverse(Y)
         elif isinstance(Y, pd.Series):
             out = Y.apply(self.inverse)
         else:

--- a/pyrolite/util/skl/transform.py
+++ b/pyrolite/util/skl/transform.py
@@ -78,7 +78,7 @@ class ExpTransform(BaseEstimator, TransformerMixin):
 
     def transform(self, X, *args, **kwargs):
         if isinstance(X, pd.DataFrame):
-            out = X.applymap(self.forward)
+            out = X.map(self.forward)
         elif isinstance(X, pd.Series):
             out = X.apply(self.forward)
         else:
@@ -87,7 +87,7 @@ class ExpTransform(BaseEstimator, TransformerMixin):
 
     def inverse_transform(self, Y, *args, **kwargs):
         if isinstance(Y, pd.DataFrame):
-            out = Y.applymap(self.inverse)
+            out = Y.map(self.inverse)
         elif isinstance(Y, pd.Series):
             out = Y.apply(self.inverse)
         else:

--- a/pyrolite/util/skl/transform.py
+++ b/pyrolite/util/skl/transform.py
@@ -78,7 +78,10 @@ class ExpTransform(BaseEstimator, TransformerMixin):
 
     def transform(self, X, *args, **kwargs):
         if isinstance(X, pd.DataFrame):
-            out = X.map(self.forward)
+            try:
+                out = X.map(self.forward)
+            except AttributeError:  # can remove when Python 3.8 is no longer supported
+                out = X.applymap(self.forward)
         elif isinstance(X, pd.Series):
             out = X.apply(self.forward)
         else:
@@ -87,7 +90,10 @@ class ExpTransform(BaseEstimator, TransformerMixin):
 
     def inverse_transform(self, Y, *args, **kwargs):
         if isinstance(Y, pd.DataFrame):
-            out = Y.map(self.inverse)
+            try:
+                out = Y.map(self.inverse)
+            except AttributeError:  # can remove when Python 3.8 is no longer supported
+                out = Y.applymap(self.inverse)
         elif isinstance(Y, pd.Series):
             out = Y.apply(self.inverse)
         else:

--- a/pyrolite/util/synthetic.py
+++ b/pyrolite/util/synthetic.py
@@ -312,7 +312,7 @@ def example_spider_data(
     df = ref.comp.pyrochem.compositional
     if norm_to is not None:
         df = df.pyrochem.normalize_to(norm_to, units=units)
-    start = df.applymap(np.log)
+    start = df.map(np.log)
     nindex = df.columns.size
 
     y = np.tile(start.values, size).reshape(size, nindex)
@@ -323,7 +323,7 @@ def example_spider_data(
     if offsets is not None:
         for element, offset in offsets.items():
             syn_df[element] += offset  # significant offset for e.g. Eu anomaly
-    syn_df = syn_df.applymap(np.exp)
+    syn_df = syn_df.map(np.exp)
     return syn_df
 
 

--- a/pyrolite/util/synthetic.py
+++ b/pyrolite/util/synthetic.py
@@ -312,10 +312,7 @@ def example_spider_data(
     df = ref.comp.pyrochem.compositional
     if norm_to is not None:
         df = df.pyrochem.normalize_to(norm_to, units=units)
-    try:
-        start = df.map(np.log)
-    except AttributeError:  # can remove when Python 3.8 is no longer supported
-        start = df.applymap(np.log)
+    start = np.log(df)
     nindex = df.columns.size
 
     y = np.tile(start.values, size).reshape(size, nindex)
@@ -326,10 +323,7 @@ def example_spider_data(
     if offsets is not None:
         for element, offset in offsets.items():
             syn_df[element] += offset  # significant offset for e.g. Eu anomaly
-    try:
-        syn_df = syn_df.map(np.exp)
-    except AttributeError:  # can remove when Python 3.8 is no longer supported
-        syn_df = syn_df.applymap(np.exp)
+    syn_df = np.exp(syn_df)
     return syn_df
 
 

--- a/pyrolite/util/synthetic.py
+++ b/pyrolite/util/synthetic.py
@@ -312,7 +312,10 @@ def example_spider_data(
     df = ref.comp.pyrochem.compositional
     if norm_to is not None:
         df = df.pyrochem.normalize_to(norm_to, units=units)
-    start = df.map(np.log)
+    try:
+        start = df.map(np.log)
+    except AttributeError:  # can remove when Python 3.8 is no longer supported
+        start = df.applymap(np.log)
     nindex = df.columns.size
 
     y = np.tile(start.values, size).reshape(size, nindex)
@@ -323,7 +326,10 @@ def example_spider_data(
     if offsets is not None:
         for element, offset in offsets.items():
             syn_df[element] += offset  # significant offset for e.g. Eu anomaly
-    syn_df = syn_df.map(np.exp)
+    try:
+        syn_df = syn_df.map(np.exp)
+    except AttributeError:  # can remove when Python 3.8 is no longer supported
+        syn_df = syn_df.applymap(np.exp)
     return syn_df
 
 

--- a/test/util/plot/util_plot_density.py
+++ b/test/util/plot/util_plot_density.py
@@ -60,7 +60,7 @@ class TestPlotZPercentiles(unittest.TestCase):
         cs = plot_Z_percentiles(
             self.xi, self.yi, zi=self.zi, contour_labels=contour_labels
         )
-        for contour_label, label in zip(contour_labels, cs.labelTextsList):
+        for contour_label, label in zip(contour_labels, cs.labelTexts):
             label = label.get_text()
             self.assertTrue(contour_label == label)
 
@@ -80,12 +80,17 @@ class TestPlotZPercentiles(unittest.TestCase):
             linestyles=linestyles,
             linewidths=linewidths,
         )
-        for contour, color, ls, lw in zip(
-            cs.collections, colors, linestyles, linewidths
-        ):
-            self.assertTrue((contour.get_edgecolor() == color).all())
-            self.assertEqual(contour.get_linestyle(), [_scale_dashes(*ls, lw)])
-            self.assertEqual(contour.get_linewidth(), lw)
+        try:
+            self.assertTrue(cs.colors == colors)
+            self.assertTrue(cs.linestyles == linestyles)
+            self.assertTrue((cs._us_lw == linewidths).all())
+        except AttributeError:  # matplotlib version < 3.8
+            for contour, color, ls, lw in zip(
+                cs.collections, colors, linestyles, linewidths
+            ):
+                self.assertTrue((contour.get_edgecolor() == color).all())
+                self.assertEqual(contour.get_linestyle(), [_scale_dashes(*ls, lw)])
+                self.assertEqual(contour.get_linewidth(), lw)
 
     def test_linestyles_specified(self):
         plot_Z_percentiles(

--- a/test/util/util_pd.py
+++ b/test/util/util_pd.py
@@ -123,7 +123,10 @@ class TestToSer(unittest.TestCase):
 
 class TestToNumeric(unittest.TestCase):
     def setUp(self):
-        self.df = normal_frame().applymap(str)
+        try:
+            self.df = normal_frame().map(str)
+        except AttributeError:
+            self.df = normal_frame().applymap(str)
 
     def test_numeric(self):
         df = self.df

--- a/test/util/util_pd.py
+++ b/test/util/util_pd.py
@@ -123,10 +123,7 @@ class TestToSer(unittest.TestCase):
 
 class TestToNumeric(unittest.TestCase):
     def setUp(self):
-        try:
-            self.df = normal_frame().map(str)
-        except AttributeError:
-            self.df = normal_frame().applymap(str)
+        self.df = normal_frame().astype(str)
 
     def test_numeric(self):
         df = self.df


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR fixes four tester errors related to matplotlib:
- the prop_cycler-related calls have been replaced with the simpler get_next_color()
- plot axes are now passed to plt.colorbar
- the argument "c" has been changed to "color" in one place
- the argument "color_by" has been changed to "color" in two places
- test change to account for contour sets no longer containing collections

This PR also addresses a deprecation warning from pandas: "DataFrame.applymap has been deprecated. Use DataFrame.map instead."

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#95 , #97

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
