### PR TITLE
Select polygons to label and fill

### DIFF
--- a/docs/source/gallery/examples/util/TAS.py
+++ b/docs/source/gallery/examples/util/TAS.py
@@ -49,11 +49,13 @@ df["Rocknames"].sample(10)  # randomly check 10 sample rocknames
 ########################################################################################
 # We could now take the TAS classes and use them to colorize our points for plotting
 # on the TAS diagram, or more likely, on another plot. Here the relationship to the
-# TAS diagram is illustrated:
+# TAS diagram is illustrated, coloring also the populated fields:
 #
 
 fig, ax = plt.subplots(1)
 
+cm.add_to_axes(ax, alpha=0.5, linewidth=0.0, zorder=-2, add_labels=False,
+               which_ids=np.unique(df["TAS"]), fill=True, facecolor=[0.9, 0.8, 1.0])
 cm.add_to_axes(ax, alpha=0.5, linewidth=0.5, zorder=-1, add_labels=True)
 df[["SiO2", "Na2O + K2O"]].pyroplot.scatter(ax=ax, c=df["TAS"], alpha=0.7, axlabels=False)
 

--- a/pyrolite/util/classification.py
+++ b/pyrolite/util/classification.py
@@ -194,6 +194,7 @@ class PolygonClassifier(object):
         axes_scale=100.0,
         add_labels=False,
         which_labels="ID",
+        which_ids=[],
         **kwargs
     ):
         """
@@ -211,6 +212,10 @@ class PolygonClassifier(object):
             Whether to add labels at polygon centroids.
         which_labels : :class:`str`
             Which data to use for field labels - field 'name' or 'ID'.
+        which_ids : :class:`list`
+            List of field IDs corresponding to the polygons to add to the axes object.
+            (e.g. for TAS, ['F', 'T1'] to plot the Foidite and Trachyte fields).
+            An empty list corresponds to plotting all the polygons.
 
         Returns
         --------
@@ -241,7 +246,7 @@ class PolygonClassifier(object):
 
         use_keys = not which_labels.lower().startswith("name")
         for k, cfg in self.fields.items():
-            if cfg["poly"]:
+            if cfg["poly"] and ((k in which_ids) or (which_ids == [])):
                 verts = self.transform(np.array(_read_poly(cfg["poly"]))) * rescale_by
                 pg = matplotlib.patches.Polygon(
                     verts,
@@ -288,6 +293,7 @@ class PolygonClassifier(object):
         axes_scale=1.0,
         add_labels=False,
         which_labels="ID",
+        which_ids=[],
         **kwargs
     ):
         """
@@ -305,6 +311,10 @@ class PolygonClassifier(object):
             Whether to add labels for the polygons.
         which_labels : :class:`str`
             Which data to use for field labels - field 'name' or 'ID'.
+        which_ids : :class:`list`
+            List of field IDs corresponding to the polygons to add to the axes object.
+            (e.g. for TAS, ['F', 'T1'] to plot the Foidite and Trachyte fields).
+            An empty list corresponds to plotting all the polygons.
 
         Returns
         --------
@@ -317,6 +327,7 @@ class PolygonClassifier(object):
             axes_scale=axes_scale,
             add_labels=add_labels,
             which_labels=which_labels,
+            which_ids=which_ids,
             **kwargs,
         )
         if self.axes is not None:
@@ -395,6 +406,7 @@ class TAS(PolygonClassifier):
         axes_scale=100.0,
         add_labels=False,
         which_labels="ID",
+        which_ids=[],
         label_at_centroid=True,
         **kwargs
     ):
@@ -414,6 +426,10 @@ class TAS(PolygonClassifier):
         which_labels : :class:`str`
             Which labels to add to the polygons (e.g. for TAS, 'volcanic', 'intrusive'
             or the field 'ID').
+        which_ids : :class:`list`
+            List of field IDs corresponding to the polygons to add to the axes object.
+            (e.g. for TAS, ['F', 'T1'] to plot the Foidite and Trachyte fields).
+            An empty list corresponds to plotting all the polygons.
         label_at_centroid : :class:`bool`
             Whether to label the fields at the centroid (True) or at the visual
             center of the field (False).
@@ -426,7 +442,8 @@ class TAS(PolygonClassifier):
         # here we don't want to add the labels in the normal way, because there
         # are two sets - one for volcanic rocks and one for plutonic rocks
         ax = self._add_polygons_to_axes(
-            ax=ax, fill=fill, axes_scale=axes_scale, add_labels=False, **kwargs
+            ax=ax, fill=fill, axes_scale=axes_scale, add_labels=False,
+            which_ids=which_ids, **kwargs
         )
 
         if not label_at_centroid:
@@ -446,7 +463,7 @@ class TAS(PolygonClassifier):
                 rescale_by = axes_scale / self.default_scale
         if add_labels:
             for k, cfg in self.fields.items():
-                if cfg["poly"]:
+                if cfg["poly"] and ((k in which_ids) or (which_ids == [])):
                     if which_labels.lower().startswith("id"):
                         label = k
                     elif which_labels.lower().startswith(

--- a/pyrolite/util/classification.py
+++ b/pyrolite/util/classification.py
@@ -246,7 +246,7 @@ class PolygonClassifier(object):
 
         use_keys = not which_labels.lower().startswith("name")
         for k, cfg in self.fields.items():
-            if cfg["poly"] and ((k in which_ids) or (which_ids == [])):
+            if cfg["poly"] and ((k in which_ids) or (len(which_ids) == 0)):
                 verts = self.transform(np.array(_read_poly(cfg["poly"]))) * rescale_by
                 pg = matplotlib.patches.Polygon(
                     verts,
@@ -463,7 +463,7 @@ class TAS(PolygonClassifier):
                 rescale_by = axes_scale / self.default_scale
         if add_labels:
             for k, cfg in self.fields.items():
-                if cfg["poly"] and ((k in which_ids) or (which_ids == [])):
+                if cfg["poly"] and ((k in which_ids) or (len(which_ids) == 0)):
                     if which_labels.lower().startswith("id"):
                         label = k
                     elif which_labels.lower().startswith(


### PR DESCRIPTION
This PR adds the option to label and fill only specific fields in classification diagrams. 

## Description
This PR adds the `which_ids` argument to the `add_to_axes` functions.

## Motivation and Context
Sometimes we might want to highlight specific fields on a classification diagram, colour them according to a specific metric, or only add labels to specific fields. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
