### PR TITLE
Allowing to compute lambda fitting on series and stop dropping PM if it is in the REE pattern

### DIFF
--- a/docs/source/dev/contributors.rst
+++ b/docs/source/dev/contributors.rst
@@ -22,3 +22,4 @@ comments, testing, bug reports, or feature requests.
 * `Sarah Shi <https://github.com/sarahshi>`__
 * `Ondrej Lexa <https://github.com/ondrolexa>`__
 * `Bob Myhill <https://github.com/bobmyhill>`__
+* `Malte Mues <https://github.com/mmuesly>`__

--- a/pyrolite/geochem/__init__.py
+++ b/pyrolite/geochem/__init__.py
@@ -24,6 +24,7 @@ class pyrochem(object):
         """Custom dataframe accessor for pyrolite geochemistry."""
         self._validate(obj)
         self._obj = obj
+        self._selection_index = self._obj.columns if isinstance(self._obj, pd.DataFrame) else self._obj.index
 
     @staticmethod
     def _validate(obj):
@@ -44,8 +45,7 @@ class pyrochem(object):
         -------
         The list will have the same ordering as the source DataFrame.
         """
-        fltr = self._obj.columns.isin(_common_elements)
-        return self._obj.columns[fltr].tolist()
+        return [i for i in self._selection_index if i in _common_elements]
 
     @property
     def list_isotope_ratios(self):
@@ -60,8 +60,7 @@ class pyrochem(object):
         -------
         The list will have the same ordering as the source DataFrame.
         """
-        fltr = [parse.is_isotoperatio(c) for c in self._obj.columns]
-        return self._obj.columns[fltr].tolist()
+        return [c for c in self._selection_index if parse.is_isotoperatio(c)]
 
     @property
     def list_REE(self):
@@ -76,7 +75,7 @@ class pyrochem(object):
         -------
         The returned list will reorder REE based on atomic number.
         """
-        return [i for i in REE() if i in self._obj.columns]
+        return [i for i in REE(dropPm=("Pm" not in self._selection_index)) if i in self._selection_index]
 
     @property
     def list_REY(self):
@@ -91,7 +90,7 @@ class pyrochem(object):
         -------
         The returned list will reorder REE based on atomic number.
         """
-        return [i for i in REY() if i in self._obj.columns]
+        return [i for i in REY(dropPm=("Pm" not in self._selection_index)) if i in self._selection_index]
 
     @property
     def list_oxides(self):
@@ -106,8 +105,8 @@ class pyrochem(object):
         -------
         The list will have the same ordering as the source DataFrame.
         """
-        fltr = self._obj.columns.isin(_common_oxides)
-        return self._obj.columns[fltr].tolist()
+        fltr = self._selection_index.isin(_common_oxides)
+        return self._selection_index[fltr].tolist()
 
     @property
     def list_compositional(self):

--- a/pyrolite/util/lambdas/helpers.py
+++ b/pyrolite/util/lambdas/helpers.py
@@ -1,0 +1,29 @@
+from pandas import DataFrame, Series
+
+
+def b_s_x2_to_df(B, s, X2, index, names, add_uncertainties, add_X2):
+    lambdas = DataFrame(
+        B,
+        index=index,
+        columns=names,
+        dtype="float32",
+    )
+    if add_uncertainties:
+        lambdas.loc[:, [n + "_" + chr(963) for n in names]] = s
+    if add_X2:
+        lambdas["X2"] = X2
+    return lambdas
+
+
+def b_s_x2_to_series(B, s, X2, names, add_uncertainties, add_X2):
+    lambdas = Series(
+        B,
+        index=names,
+        dtype="float32",
+    )
+    if add_uncertainties:
+        for i, n in enumerate(names):
+            lambdas.loc[n + "_" + chr(963)] = s[i]
+    if add_X2:
+        lambdas["X2"] = X2
+    return lambdas

--- a/pyrolite/util/lambdas/oneill.py
+++ b/pyrolite/util/lambdas/oneill.py
@@ -10,6 +10,7 @@ from ..meta import update_docstring_references
 from ..missing import md_pattern
 from .eval import get_function_components, lambda_poly
 from .params import parse_sigmas
+from .helpers import b_s_x2_to_df, b_s_x2_to_series
 
 logger = Handle(__name__)
 
@@ -41,6 +42,90 @@ def get_polynomial_matrix(radii, params=None):
     A_radii = a[:, np.newaxis, :] * b[np.newaxis, :, :]
     A = A_radii.sum(axis=-1)  # `A` as in O'Neill (2016)
     return A
+
+
+def lambdas_ONeill2016_series(
+    series,
+    radii,
+    params=None,
+    sigmas=None,
+    add_X2=False,
+    add_uncertainties=False,
+    **kwargs
+):
+    r"""
+    This is a variant of :func:`~pyrolite.geochem.lambdas_ONeill2016`
+    adapted to work on a Series instead of a DataFrame.
+    Implementation of the original algorithm. [#ref_1]_
+
+    Parameters
+    -----------
+    series : :class:`pandas.Series`
+        Series of REE data, with sample analyses organised by row.
+    radii : :class:`list`, :class:`numpy.ndarray`
+        Radii at which to evaluate the orthogonal polynomial.
+    params : :class:`tuple`
+        Tuple of constants for the orthogonal polynomial.
+    sigmas : :class:`float` | :class:`numpy.ndarray`
+        Single value or 1D array of normalised observed value uncertainties
+        (:math:`\sigma_{REE} / REE`).
+    add_uncertainties : :class:`bool`
+        Append parameter standard errors to the dataframe.
+
+    Returns
+    --------
+    :class:`pandas.Series`
+
+    See Also
+    ---------
+    :func:`~pyrolite.util.lambdas.params.orthogonal_polynomial_constants`
+    :func:`~pyrolite.geochem.transform.lambda_lnREE`
+
+    References
+    -----------
+    .. [#ref_1] O’Neill HSC (2016) The Smoothness and Shapes of Chondrite-normalized
+           Rare Earth Element Patterns in Basalts. J Petrology 57:1463–1508.
+           doi: `10.1093/petrology/egw047 <https://dx.doi.org/10.1093/petrology/egw047>`__
+
+    """
+    assert params is not None
+    names, x0, func_components = get_function_components(radii, params=params)
+    X = np.array(func_components).T
+    sigmas = parse_sigmas(series.size, sigmas=sigmas)
+
+    xd = len(func_components)
+    rad = np.array(radii)
+
+    B = np.ones(xd) * np.nan
+    s = np.ones(xd) * np.nan
+
+    missing_fltr = np.isfinite(series)
+    numberOfPresentElemetns = missing_fltr.sum()
+
+    A = get_polynomial_matrix(rad[missing_fltr], params=params)
+    invA = np.linalg.inv(A)
+    V = np.vander(rad, xd, increasing=True).T
+    Z = (series.values[missing_fltr][np.newaxis, :] * V[:, missing_fltr]).sum(axis=-1)
+    _B = (invA @ Z.T).T
+    ############################################################################
+    _sigmas = sigmas[missing_fltr]
+    _x = X[missing_fltr, :]
+    W = np.eye(_sigmas.shape[0]) * 1 / _sigmas**2  # weights
+    invXWX = np.linalg.inv(_x.T @ W @ _x)
+
+    est = (X[missing_fltr] @ _B.T).T  # modelled values
+    # residuals over all rows
+    residuals = (series.loc[missing_fltr] - est).values
+    dof = (
+        numberOfPresentElemetns - xd
+    )  # effective degrees of freedom (for this mising filter)
+    # chi-sqared as SSQ / sigmas / residual degrees of freedom
+    reduced_chi_squared = (residuals**2 / _sigmas**2).sum() / dof
+    _s = np.sqrt(reduced_chi_squared.reshape(-1, 1) * np.diag(invXWX))
+
+    B[:] = _B
+    s[:] = _s
+    return b_s_x2_to_series(B, s, reduced_chi_squared, names, add_uncertainties, add_X2)
 
 
 @update_docstring_references
@@ -84,7 +169,7 @@ def lambdas_ONeill2016(
     names, x0, func_components = get_function_components(radii, params=params)
     X = np.array(func_components).T
     y = df.values
-    sigmas = parse_sigmas(y, sigmas=sigmas)
+    sigmas = parse_sigmas(y.shape[1], sigmas=sigmas)
 
     xd = len(func_components)
     rad = np.array(radii)  # so we can use a boolean index
@@ -92,7 +177,6 @@ def lambdas_ONeill2016(
     B = np.ones((y.shape[0], xd)) * np.nan
     s = np.ones((y.shape[0], xd)) * np.nan
     χ2 = np.ones((y.shape[0], 1)) * np.nan
-
     md_inds, patterns = md_pattern(df)
     # for each missing data pattern, we create the matrix A - rather than each row
     for ind in np.unique(md_inds):
@@ -126,15 +210,4 @@ def lambdas_ONeill2016(
             B[row_fltr, :] = _B
             s[row_fltr, :] = _s
             χ2[row_fltr, 0] = reduced_chi_squared
-
-    lambdas = pd.DataFrame(
-        B,
-        index=df.index,
-        columns=names,
-        dtype="float32",
-    )
-    if add_uncertainties:
-        lambdas.loc[:, [n + "_" + chr(963) for n in names]] = s
-    if add_X2:
-        lambdas["X2"] = χ2
-    return lambdas
+    return b_s_x2_to_df(B, s, χ2, df.index, names, add_uncertainties, add_X2)

--- a/pyrolite/util/lambdas/opt.py
+++ b/pyrolite/util/lambdas/opt.py
@@ -11,7 +11,8 @@ from ..log import Handle
 from ..meta import update_docstring_references
 from ..missing import md_pattern
 from .eval import get_function_components
-from .params import parse_sigmas
+from .params import parse_sigmas, _get_params
+from .helpers import b_s_x2_to_df, b_s_x2_to_series
 
 logger = Handle(__name__)
 
@@ -116,7 +117,7 @@ def linear_fit_components(y, x0, func_components, sigmas=None):
     X = np.array(func_components).T  # components as vectors [1 f0 f1 f2]
     xd = len(func_components)  # number of parameters
 
-    sigmas = parse_sigmas(y, sigmas=sigmas)
+    sigmas = parse_sigmas(y.shape[1], sigmas=sigmas)
 
     B = np.ones((y.shape[0], len(func_components))) * np.nan
     s = np.ones((y.shape[0], len(func_components))) * np.nan
@@ -164,6 +165,124 @@ def linear_fit_components(y, x0, func_components, sigmas=None):
     return B, s, χ2
 
 
+def linear_fit_components_series(series, x0, func_components, sigmas=None):
+    r"""
+    Fit a weighted sum of function components using linear algebra.
+
+    Parameters
+    -----------
+    series : :class:`numpy.ndarray`
+        Array of target values to fit.
+    x0 : :class:`numpy.ndarray`
+        Starting guess for the function weights.
+    func_components : :class:`list` ( :class:`numpy.ndarray` )
+        List of arrays representing static/evaluated function components.
+    sigmas : :class:`float` | :class:`numpy.ndarray`
+        Single value or 1D array of normalised observed value uncertainties
+        (:math:`\sigma_{REE} / REE`).
+
+    Returns
+    -------
+    B, s, χ2 : :class:`numpy.ndarray`
+        Arrays for the optimized parameter values (B; (n, d)), parameter
+        uncertaintes (s, 1σ; (n, d)) and chi-chi_squared (χ2; (n, 1)).
+    """
+    X = np.array(func_components).T  # components as vectors [1 f0 f1 f2]
+    xd = len(func_components)  # number of parameters
+
+    sigmas = parse_sigmas(series.size, sigmas=sigmas)
+
+    B = np.ones(len(func_components)) * np.nan
+    s = np.ones(len(func_components)) * np.nan
+
+    missing_fltr = np.isfinite(series)
+    numberOfPresentElemetns = missing_fltr.sum()
+    _x, _y, _sigmas = (
+        X[missing_fltr],
+        series[missing_fltr],
+        sigmas[missing_fltr],
+    )
+    # weights derived from reciprocal variance of y-uncertaintes
+    # W = np.eye(_sigmas.shape[0]) * 1 / _sigmas ** 2  # weights
+    # assuming the errors on y are uncorrelated, we can use _sigmas as
+    # whitening transformation for X and y:
+    # w = np.diag(np.sqrt(W))
+    w = 1 / _sigmas
+    _x *= w.reshape(-1, 1)
+    _y *= w
+
+    invXX = np.linalg.inv(_x.T @ _x)
+    _B = (invXX @ _x.T @ _y.T).T  # parameter estimates
+    ############################################################################
+    est = (_x @ _B.T).T  # estimated values of y
+    residuals = _y - est  # residuals
+    S = (residuals**2).sum()  # residual sum of squares
+    # H = X @ invXWX @ X.T @ W  # Hat matrix
+    dof = numberOfPresentElemetns - xd  # effective degrees of freedom (for this mising filter)
+    # calculate the reduced_chi_squared per row (divided by degrees of freedom)
+    # note due to the whitening transformation above, S is effectively
+    # sum(residual/sigma)**2
+    reduced_chi_squared = S / dof
+    _s = np.sqrt(reduced_chi_squared.reshape(-1, 1) * np.diag(invXX))
+
+    return _B, _s[0], reduced_chi_squared
+
+
+def optimize_fit_components_series(
+    series, x0, func_components, residuals_function=_residuals_func, sigmas=None
+):
+    r"""
+    Fit a weighted sum of function components using
+    :func:`scipy.optimize.least_squares`.
+
+    Parameters
+    -----------
+    series : :class:`numpy.ndarray`
+        Array of target values to fit.
+    x0 : :class:`numpy.ndarray`
+        Starting guess for the function weights.
+    func_components : :class:`list` ( :class:`numpy.ndarray` )
+        List of arrays representing static/evaluated function components.
+    redsiduals_function : callable
+        Callable funciton to compute residuals which accepts ordered arguments for
+        weights, target values and function components.
+    sigmas : :class:`float` | :class:`numpy.ndarray`
+        Single value or 1D array of normalised observed value uncertainties
+        (:math:`\sigma_{REE} / REE`).
+
+    Returns
+    -------
+    B, s, χ2 : :class:`numpy.ndarray`
+        Arrays for the optimized parameter values (B; (n, d)), parameter
+        uncertaintes (s, 1σ; (n, d)) and chi-chi_squared (χ2; (n, 1)).
+    """
+    sigmas = parse_sigmas(series.size, sigmas=sigmas)
+    B = np.ones(len(func_components)) * np.nan
+    s = np.ones(len(func_components)) * np.nan
+    res = scipy.optimize.least_squares(
+        residuals_function,
+        x0,
+        args=(
+            series,
+            func_components,
+        ),
+    )
+    # get the covariance matrix of the parameters from the jacobian
+    pcov = pcov_from_jac(res.jac)
+    yd, xd = series.size, x0.size
+    if yd > xd:  # check samples in y vs parameter dimension
+        s_sq = res.cost / (yd - xd)
+        pcov = pcov * s_sq
+    else:
+        pcov.fill(np.inf)
+
+    dof = yd - xd  # effective degrees of freedom
+    reduced_chi_squared = (res.fun**2 / sigmas**2).sum() / dof
+    B[:] = res.x
+    s[:] = np.sqrt(np.diag(pcov))  # sigmas on parameters
+    return B, s, reduced_chi_squared
+
+
 def optimize_fit_components(
     y, x0, func_components, residuals_function=_residuals_func, sigmas=None
 ):
@@ -193,7 +312,7 @@ def optimize_fit_components(
         uncertaintes (s, 1σ; (n, d)) and chi-chi_squared (χ2; (n, 1)).
     """
     m, _ = y.shape[0], x0.size  # shape of output
-    sigmas = parse_sigmas(y, sigmas=sigmas)
+    sigmas = parse_sigmas(y.shape[1], sigmas=sigmas)
     B = np.ones((y.shape[0], len(func_components))) * np.nan
     s = np.ones((y.shape[0], len(func_components))) * np.nan
     χ2 = np.ones((y.shape[0], 1)) * np.nan
@@ -224,11 +343,91 @@ def optimize_fit_components(
 
 
 @update_docstring_references
+def lambdas_optimize_series(
+    series: pd.Series,
+    radii,
+    params=None,
+    fit_tetrads=False,
+    tetrad_params=None,
+    fit_method="opt",
+    sigmas=None,
+    add_uncertainties=False,
+    add_X2=False,
+    degree=5,
+    **kwargs
+):
+    """
+    Parameterises values based on linear combination of orthogonal polynomials
+    over a given set of values for independent variable `x`. [#ref_1]_
+
+    Parameters
+    -----------
+    series : :class:`pandas.Series`
+        Target data to fit. For geochemical data, this is typically normalised
+        so we can fit a smooth function.
+    radii : :class:`list`, :class:`numpy.ndarray`
+        Radii at which to evaluate the orthogonal polynomial.
+    params : :class:`list`, :code:`None`
+        Orthogonal polynomial coefficients (see
+        :func:`orthogonal_polynomial_constants`).
+    fit_tetrads : :class:`bool`
+        Whether to also fit the patterns for tetrads.
+    tetrad_params : :class:`list`
+        List of parameter sets for tetrad functions.
+    fit_method : :class:`str`
+        Which fit method to use: :code:`"optimization"` or :code:`"linear"`.
+    sigmas : :class:`float` | :class:`numpy.ndarray`
+        Single value or 1D array of observed value uncertainties.
+    add_uncertainties : :class:`bool`
+        Whether to append estimated parameter uncertainties to the dataframe.
+    add_X2 : :class:`bool`
+        Whether to append the chi-squared values (χ2) to the dataframe.
+
+    Returns
+    --------
+    :class:`numpy.ndarray` | (:class:`numpy.ndarray`, :class:`numpy.ndarray`)
+        Optimial results for weights of orthogonal polymomial regression (`lambdas`).
+
+    See Also
+    ---------
+    :func:`~pyrolite.util.lambdas.params.orthogonal_polynomial_constants`
+    :func:`~pyrolite.geochem.transform.lambda_lnREE`
+
+    References
+    ----------
+    .. [#ref_1] O’Neill HSC (2016) The Smoothness and Shapes of Chondrite-normalized
+           Rare Earth Element Patterns in Basalts. J Petrology 57:1463–1508.
+           doi: `10.1093/petrology/egw047 <https://dx.doi.org/10.1093/petrology/egw047>`__
+    """
+    if not params:
+        params = _get_params(None, degree)
+    assert params is not None  # degree = len(params)
+
+    # arrays representing the unweighted individual polynomial components
+    names, x0, func_components = get_function_components(
+        radii, params=params, fit_tetrads=fit_tetrads, tetrad_params=tetrad_params
+    )
+    if fit_method.lower().startswith("opt"):
+        fit = optimize_fit_components_series
+    else:
+        fit = linear_fit_components_series
+
+    B, s, χ2 = fit(
+        series.pyrochem.REE.values,
+        np.array(x0),
+        func_components,
+        sigmas=sigmas,
+        **kwargs
+    )
+
+    return b_s_x2_to_series(B, s, χ2, names, add_uncertainties, add_X2)
+
+
+@update_docstring_references
 def lambdas_optimize(
     df: pd.DataFrame,
     radii,
     params=None,
-    guess=None,
     fit_tetrads=False,
     tetrad_params=None,
     fit_method="opt",
@@ -280,8 +479,8 @@ def lambdas_optimize(
            Rare Earth Element Patterns in Basalts. J Petrology 57:1463–1508.
            doi: `10.1093/petrology/egw047 <https://dx.doi.org/10.1093/petrology/egw047>`__
     """
-    assert params is not None # degree = len(params)
-    
+    assert params is not None  # degree = len(params)
+
     # arrays representing the unweighted individual polynomial components
     names, x0, func_components = get_function_components(
         radii, params=params, fit_tetrads=fit_tetrads, tetrad_params=tetrad_params
@@ -295,14 +494,4 @@ def lambdas_optimize(
         df.pyrochem.REE.values, np.array(x0), func_components, sigmas=sigmas, **kwargs
     )
 
-    lambdas = pd.DataFrame(
-        B,
-        index=df.index,
-        columns=names,
-        dtype="float32",
-    )
-    if add_uncertainties:
-        lambdas.loc[:, [n + "_" + chr(963) for n in names]] = s
-    if add_X2:
-        lambdas["X2"] = χ2
-    return lambdas
+    return b_s_x2_to_df(B, s, χ2, df.index, names, add_uncertainties, add_X2)

--- a/pyrolite/util/lambdas/params.py
+++ b/pyrolite/util/lambdas/params.py
@@ -152,7 +152,7 @@ def _get_params(params=None, degree=4):
     return params
 
 
-def parse_sigmas(y, sigmas=None):
+def parse_sigmas(size, sigmas=None):
     r"""
     Disambigaute a value or set of sigmas for a dataset for use in lambda-fitting
     algorithms.
@@ -180,10 +180,10 @@ def parse_sigmas(y, sigmas=None):
     0.01 will be returned.
     """
     if sigmas is None:
-        sigmas = np.ones(y.shape[1]) * 0.01
+        sigmas = np.ones(size) * 0.01
     else:  # sigmas are passed
         if isinstance(sigmas, float):
-            sigmas = sigmas * np.ones(y.shape[1])
+            sigmas = sigmas * np.ones(size)
         elif sigmas.ndim > 1:
             if any(ix == 1 for ix in sigmas.shape):
                 sigmas = sigmas.flatten()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We love the implementation for characterizing tetrades in REE patterns on a dataframe. For performance considerations, we require to wrap the implementation into an apply function on a dataframe. In its current form, it is not possible to compute lambdas only on a single series. I suggest to change the implementation to also support the core computation of lambdas on series objects. As a consequence, it can be used inside an apply function and offers easy parallelization in combination with the [pandarallel](https://github.com/nalepae/pandarallel) package.

Moreover, I would love to stop the pyrochem.REE to drop PM if it is already in the dataset. Preparing plots gets more complicated if the already added column is dropped by this column.

## Related Issue
#99 

## Motivation and Context
Apart from solving a performance issue, it also allows to define in a dataset excluded elements for each sample and which samples should be fitted using the LTE effect or not. When integrating lambda fitting into larger pipelines, it is easier to work on a per sample base than splitting the dataset into multiple data frames upfront.

We have many pipelines that use `pyrochem.REE` for selecting the REE pattern before plotting. We love to maintain the PM column in the pattern, if it is already present in the data set.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] New feature (non-breaking change which adds functionality)
- [ x] Breaking change (fix or feature that would cause existing functionality to change)
Keeping the PM column if present is a breaking change. Currently, it is always dropped using `pyrochem.REE`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [] I have updated the documentation accordingly. (Eventually, there is some more to add to `pyrochem.REE`. Not sure.)
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.


I am happy to make further changes to this PR.