### PR TITLE
Checks for negative entries in close and normalise functions of codata.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+.DS_Store
 
 # C extensions
 *.so

--- a/pyrolite/comp/codata.py
+++ b/pyrolite/comp/codata.py
@@ -80,13 +80,13 @@ def renormalise(df: pd.DataFrame, components: list = [], scale=100.0):
             raise ValueError("Not all specified components exist in the DataFrame.")
         dfc = dfc[components]
 
-    # Replace negative values with NaN
-    dfc[dfc < 0] = np.nan
-
     if (dfc <= 0).any().any():
         warnings.warn("Non-positive entries found in specified components. "
                       "Negative values have been replaced with NaN. "
                       "Renormalisation assumes all positive entries.", UserWarning)
+
+    # Replace negative values with NaN
+    dfc[dfc < 0] = np.nan
 
     # Renormalise all columns if no components are specified
     sum_rows = dfc.sum(axis=1)


### PR DESCRIPTION
## Description
I modified functions within codata.py to return a UserWarning for when negative values are in either the array for the close function or in the dataframe for the normalise function.

## Related Issue
See enhancement described here: 
https://github.com/morganjwilliams/pyrolite/issues/103

## Motivation and Context
This is a small quality of life improvement for these functions. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
